### PR TITLE
Update URL for 'MoreVP Plasma Explained' Hyperlink

### DIFF
--- a/guides/get_started.md
+++ b/guides/get_started.md
@@ -1,6 +1,6 @@
 ### Getting Started
 
-- For those who are curious to learn more about OMG Network architecture and what you can build with it, we recommend you read this [MoreVP Plasma Explained](https://github.com/omisego/dev-portal/blob/master/guides/get_started.md)
+- For those who are curious to learn more about OMG Network architecture and what you can build with it, we recommend you read this [MoreVP Plasma Explained](https://github.com/omisego/dev-portal/blob/master/guides/morevp_eli5.md)
 
 - For those who would like to get a hands-on experience interacting with Plasma's interface, we recommend reading [Plasma Interface From The Browser](https://github.com/omisego/dev-portal/blob/master/guides/plasma_interface_from_browser.md)
 


### PR DESCRIPTION
**ISSUE:** The URL associated with the 'MoreVP Plasma Explained' hyperlink currently points to /get_started.md. 

**PROPOSAL:** Update the hyperlink to reference /morevp_eli5.md. 