### PR TITLE
Fixed typo

### DIFF
--- a/frontend/src/pages/landing-page/LandingPage.js
+++ b/frontend/src/pages/landing-page/LandingPage.js
@@ -158,7 +158,7 @@ const LandingPage = () => {
           </span>
           <span>
             <Typography center color='text'>
-              {`Leverage Plasma architecture to build a L2 Application with\nhigh throughputs and strong safety gaurantees`}
+              {`Leverage Plasma architecture to build a L2 Application with\nhigh throughputs and strong safety guarantees`}
             </Typography>
           </span>
           <span>


### PR DESCRIPTION
Fixed typo 'gaurantees' to 'guarantees', in “Leverage Plasma architecture to build a L2 Application with
high throughputs and strong safety gaurantees” - last word should be ‘guarantees’